### PR TITLE
openssl bitcode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you do not want to build it by yourself, you could download our prebuilt libr
 ### For iOS
 
 - Xcode info: Version 11.3.1 (11C504) (for reference only)
-- Build dependencies: todo
+- Build dependencies: pkg-config
 - Build order: 1.build openssl, 2.build nghttp2, 3.build curl (curl depend openssl and nghttp2)
 - only build static library(.a)
 - build sh cmd: for example:
@@ -75,7 +75,7 @@ $ sh build-ios-curl.sh
 
 - Android Studio info: 4.1, November 5, 2020 (for reference only)
 - Android NDK info: r21d
-- Build dependencies: todo
+- Build dependencies: pkg-config
 - Build order: 1.build openssl, 2.build nghttp2, 3.build curl (curl depend openssl and nghttp2)
 - build static library(.a) and dynamic library (exclude curl arm64-v8a)
 - env macro: for example:

--- a/tools/build-ios-openssl.sh
+++ b/tools/build-ios-openssl.sh
@@ -93,19 +93,19 @@ function configure_make() {
 
         # openssl1.1.1d can be set normally, 1.1.0f does not take effect
         ./Configure iphoneos-cross no-shared --prefix="${PREFIX_DIR}"
-        sed -ie "s!-fno-common!-fno-common -fembed-bitcode !" "Makefile"
+        sed -ie "s!-fno-common!-fno-common !" "Makefile"
 
     elif [[ "${ARCH}" == "arm64" ]]; then
 
         # openssl1.1.1d can be set normally, 1.1.0f does not take effect
         ./Configure iphoneos-cross no-shared --prefix="${PREFIX_DIR}"
-        sed -ie "s!-fno-common!-fno-common -fembed-bitcode !" "Makefile"
+        sed -ie "s!-fno-common!-fno-common !" "Makefile"
 
     elif [[ "${ARCH}" == "arm64e" ]]; then
 
         # openssl1.1.1d can be set normally, 1.1.0f does not take effect
         ./Configure iphoneos-cross no-shared --prefix="${PREFIX_DIR}"
-        sed -ie "s!-fno-common!-fno-common -fembed-bitcode !" "Makefile"
+        sed -ie "s!-fno-common!-fno-common !" "Makefile"
 
     else
         log_error "not support" && exit 1


### PR DESCRIPTION
updates:
- build-ios-openssl.sh - remove removal of -fembed-bitcode
- README.md - make reference to pkg-config as a build tool dependency. I didn't have it installed and had to get it via brew